### PR TITLE
add database tests, CLAUDE.md, and gitignore improvements

### DIFF
--- a/.github/workflows/dream_analyser.yml
+++ b/.github/workflows/dream_analyser.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:
-        version: latest
+        version: 2.0.1
         virtualenvs-create: true
         virtualenvs-in-project: true
 

--- a/.github/workflows/dream_analyser.yml
+++ b/.github/workflows/dream_analyser.yml
@@ -49,7 +49,7 @@ jobs:
         poetry run python -c "import nltk; nltk.download('brown', quiet=True)"
 
     - name: Run tests with pytest
-      run: poetry run pytest -v --cov=dream_interpreter --cov-report=xml --cov-report=term-missing
+      run: poetry run pytest -v --cov=dream_interpreter --cov-report=xml --cov-report=term-missing --cov-fail-under=83
 
   lint:
     runs-on: ubuntu-latest
@@ -64,6 +64,10 @@ jobs:
 
     - name: Install Poetry
       uses: snok/install-poetry@v1
+      with:
+        version: 2.0.1
+        virtualenvs-create: true
+        virtualenvs-in-project: true
 
     - name: Install dependencies
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Thumbs.db
 # Testing
 .pytest_cache/
 .coverage
+coverage.xml
 htmlcov/
 
 # Logs
@@ -47,3 +48,6 @@ htmlcov/
 
 # Local development
 .envrc
+
+# Claude Code
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# Dream Analyser — Claude Code Guide
+
+## Project Overview
+
+FastAPI service that analyzes dream descriptions and generates evolving visual symbols. Dreams are scored on two dimensions and stored per user; the symbol grows more complex with each dream logged.
+
+Deployed on Railway via Docker. Live at the URL in the README.
+
+## Architecture
+
+```
+dream_interpreter/
+├── main.py            # FastAPI app + embedded HTML/JS web UI
+├── analyser.py        # Core scoring engine (TextBlob + keyword matching)
+├── database.py        # In-memory store (no persistence — data lost on restart)
+├── models.py          # Pydantic models for all request/response shapes
+└── symbol_generator.py # matplotlib PNG generator, returns base64 string
+```
+
+### Two-Dimensional Scoring Model
+
+Every dream is scored on two independent axes:
+
+| Axis | Range | Meaning |
+|------|-------|---------|
+| `upper_downer_score` | −1 to 1 | Emotional valence: −1 = very negative, +1 = very positive |
+| `static_dynamic_score` | −1 to 1 | Energy level: −1 = very still/passive, +1 = very active |
+
+These two scores place each dream in one of four quadrants (Dynamic Upper, Static Upper, Dynamic Downer, Static Downer). The quadrant history drives the evolving symbol.
+
+### Key Design Decisions
+
+- **In-memory only**: `DreamDatabase` uses plain dicts. No SQLAlchemy, no file persistence. This is intentional for the demo — `user_id` defaults to `"anonymous"` when omitted.
+- **Confidence score**: Derived from text length (longer = more confident) + keyword hit density. Caps at 1.0.
+- **Symbol layers**: One layer added per dream, capped at 10. Colours map to emotional tone; shapes indicate energy level.
+- **scikit-learn** is listed as a dependency but currently unused — reserved for a planned TF-IDF upgrade to the analyser.
+- **Web UI** is embedded directly in `main.py` as an HTML string (no template engine). Keep it that way unless adding Jinja2.
+
+## Development Commands
+
+```bash
+make install        # Install dependencies via Poetry
+make run            # Start dev server on http://localhost:8000
+make test           # Run pytest
+make test-coverage  # Run pytest with coverage (XML + terminal)
+make lint           # Run pylint across src + tests
+make fmt            # Format with isort then Black
+make setup-nltk     # Download punkt + brown NLTK data (required for TextBlob)
+make clean          # Remove build artefacts and caches
+```
+
+Run `make setup-nltk` once after a fresh install — TextBlob will fail without it.
+
+## Testing
+
+- Framework: pytest with pytest-asyncio
+- HTTP client: httpx (via `AsyncClient` + `ASGITransport`)
+- Three test files mirror the three main modules: `test_analyser.py`, `test_api.py`, `test_symbol_generator.py`
+- Target coverage: 83%+ (tracked in CI)
+- Run `make test-coverage` to see per-file line coverage
+
+## Code Conventions
+
+- **Formatter**: Black, line length 88
+- **Imports**: isort
+- **Linter**: Pylint, minimum score 8.0 (enforced in CI via `make lint-ci`)
+- **Type hints**: Required on all public functions
+- **Docstrings**: Google-style on all classes and public methods
+- **Private helpers**: Prefix with `_` (e.g. `_calculate_emotional_score`)
+- **Models**: All API input/output uses Pydantic `BaseModel` with field-level validation
+
+## CI/CD
+
+Two GitHub Actions workflows:
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| `dream_analyser.yml` | push/PR to main & develop | Tests on Python 3.9–3.12 + Black/isort/pylint checks |
+| `build.yml` | push/PR to main | Builds Docker image; pushes to ghcr.io on merge to main |

--- a/dream_interpreter/analyser.py
+++ b/dream_interpreter/analyser.py
@@ -1,18 +1,121 @@
+"""Dream analysis using either a Claude API call or a legacy rule-based fallback."""
 import re
-from typing import Dict, List, Tuple
+from typing import List
 
-import numpy as np
-from sklearn.feature_extraction.text import TfidfVectorizer
+import anthropic
 from textblob import TextBlob
 
 from .models import DreamAnalysis
 
+_TOOL_SCHEMA = [
+    {
+        "name": "record_dream_analysis",
+        "description": "Record the structured analysis of a dream.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "upper_downer_score": {
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1,
+                    "description": (
+                        "Emotional valence: -1 = deeply negative/fearful, "
+                        "0 = neutral, 1 = joyful/transcendent."
+                    ),
+                },
+                "static_dynamic_score": {
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1,
+                    "description": (
+                        "Energy level: -1 = passive/still/observational, "
+                        "0 = mixed, 1 = active/energetic/kinetic."
+                    ),
+                },
+                "confidence": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1,
+                    "description": (
+                        "How clearly the text expresses emotional and energetic "
+                        "content. Short or ambiguous texts score lower."
+                    ),
+                },
+                "keywords": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "maxItems": 10,
+                    "description": "Up to 10 significant dream elements.",
+                },
+            },
+            "required": [
+                "upper_downer_score",
+                "static_dynamic_score",
+                "confidence",
+                "keywords",
+            ],
+        },
+    }
+]
 
-class Dreamanalyser:
-    """Analyses dreams for emotional and dynamic content."""
+_SYSTEM_PROMPT = (
+    "You are a dream analysis engine. Score the dream on two axes:\n"
+    "- upper_downer_score: float in [-1, 1], where -1 is deeply negative/fearful, "
+    "0 is neutral, 1 is joyful/transcendent.\n"
+    "- static_dynamic_score: float in [-1, 1], where -1 is passive/still/observational, "
+    "0 is mixed, 1 is active/energetic/kinetic.\n"
+    "- confidence: float in [0, 1] reflecting how clearly the text expresses emotional "
+    "and energetic content. Short or ambiguous texts score lower.\n"
+    "- keywords: list of up to 10 significant dream elements (not limited to any "
+    "predefined vocabulary).\n"
+    "Use the provided tool to record your analysis."
+)
+
+
+class LLMDreamanalyser:  # pylint: disable=too-few-public-methods
+    """Analyses dreams using the Claude API for context-aware scoring."""
+
+    def __init__(
+        self,
+        model: str = "claude-haiku-4-5-20251001",
+        anthropic_client: anthropic.AsyncAnthropic = None,
+    ):
+        """Initialise the analyser.
+
+        Args:
+            model: Claude model ID to use for analysis.
+            anthropic_client: Optional pre-built Anthropic client (useful for testing).
+        """
+        self._client = anthropic_client or anthropic.AsyncAnthropic()
+        self._model = model
+
+    async def analyze_dream(self, dream_text: str) -> DreamAnalysis:
+        """Analyse a dream via Claude API tool use and return structured scores.
+
+        Args:
+            dream_text: The raw dream description to analyse.
+
+        Returns:
+            A DreamAnalysis with scores and extracted keywords.
+        """
+        message = await self._client.messages.create(
+            model=self._model,
+            max_tokens=256,
+            temperature=0,
+            system=_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": dream_text}],
+            tools=_TOOL_SCHEMA,
+            tool_choice={"type": "any"},
+        )
+        tool_input = message.content[0].input
+        return DreamAnalysis(**tool_input)
+
+
+class LegacyDreamanalyser:  # pylint: disable=too-few-public-methods
+    """Rule-based dream analyser using TextBlob sentiment and keyword matching."""
 
     def __init__(self):
-        # Predefined word lists for dream analysis
+        """Initialise predefined word sets for scoring."""
         self.upper_words = {
             "flying",
             "soaring",
@@ -107,22 +210,22 @@ class Dreamanalyser:
         }
 
     def analyze_dream(self, dream_text: str) -> DreamAnalysis:
-        """Analyze a dream text and return emotional/dynamic scores."""
-        # Clean and process text
+        """Analyse a dream text and return emotional/dynamic scores.
+
+        Args:
+            dream_text: The raw dream description to analyse.
+
+        Returns:
+            A DreamAnalysis with scores and extracted keywords.
+        """
         cleaned_text = self._clean_text(dream_text)
 
-        # Get sentiment analysis
         blob = TextBlob(cleaned_text)
         sentiment_polarity = blob.sentiment.polarity
 
-        # Calculate scores
         upper_downer = self._calculate_emotional_score(cleaned_text, sentiment_polarity)
         static_dynamic = self._calculate_dynamic_score(cleaned_text)
-
-        # Extract keywords
         keywords = self._extract_keywords(cleaned_text)
-
-        # Calculate confidence based on text length and keyword matches
         confidence = self._calculate_confidence(cleaned_text, keywords)
 
         return DreamAnalysis(
@@ -133,7 +236,7 @@ class Dreamanalyser:
         )
 
     def _clean_text(self, text: str) -> str:
-        """Clean and normalize text."""
+        """Clean and normalise text."""
         text = text.lower()
         text = re.sub(r"[^\w\s]", " ", text)
         text = " ".join(text.split())
@@ -146,15 +249,11 @@ class Dreamanalyser:
         upper_count = len(words & self.upper_words)
         downer_count = len(words & self.downer_words)
 
-        # Combine keyword-based scoring with sentiment analysis
         keyword_score = 0
         if upper_count > 0 or downer_count > 0:
             keyword_score = (upper_count - downer_count) / (upper_count + downer_count)
 
-        # Weight sentiment analysis and keyword matching
         final_score = 0.6 * sentiment + 0.4 * keyword_score
-
-        # Ensure score is within bounds
         return max(-1.0, min(1.0, final_score))
 
     def _calculate_dynamic_score(self, text: str) -> float:
@@ -165,7 +264,6 @@ class Dreamanalyser:
         static_count = len(words & self.static_words)
 
         if dynamic_count == 0 and static_count == 0:
-            # Default to slightly dynamic for most dreams
             return 0.1
 
         total = dynamic_count + static_count
@@ -179,7 +277,6 @@ class Dreamanalyser:
         """Extract key terms from dream text."""
         words = text.split()
 
-        # Find matches with our predefined word sets
         all_keywords = (
             self.upper_words
             | self.downer_words
@@ -188,7 +285,6 @@ class Dreamanalyser:
         )
         found_keywords = [word for word in words if word in all_keywords]
 
-        # Remove duplicates while preserving order
         unique_keywords = []
         seen = set()
         for keyword in found_keywords:
@@ -196,18 +292,19 @@ class Dreamanalyser:
                 unique_keywords.append(keyword)
                 seen.add(keyword)
 
-        return unique_keywords[:10]  # Limit to top 10 keywords
+        return unique_keywords[:10]
 
     def _calculate_confidence(self, text: str, keywords: List[str]) -> float:
         """Calculate confidence in the analysis."""
         text_length = len(text.split())
         keyword_count = len(keywords)
 
-        # Base confidence on text length (more text = higher confidence)
-        length_factor = min(1.0, text_length / 50.0)  # Cap at 50 words
-
-        # Boost confidence based on keyword matches
-        keyword_factor = min(1.0, keyword_count / 5.0)  # Cap at 5 keywords
+        length_factor = min(1.0, text_length / 50.0)
+        keyword_factor = min(1.0, keyword_count / 5.0)
 
         confidence = 0.5 + 0.3 * length_factor + 0.2 * keyword_factor
         return min(1.0, confidence)
+
+
+# Backward-compatibility alias — existing imports of Dreamanalyser still work.
+Dreamanalyser = LegacyDreamanalyser

--- a/dream_interpreter/main.py
+++ b/dream_interpreter/main.py
@@ -1,12 +1,18 @@
+import inspect
+import os
 from datetime import datetime
+
+from dotenv import load_dotenv
+
+load_dotenv()
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 
-from .analyser import Dreamanalyser
+from .analyser import Dreamanalyser, LLMDreamanalyser
 from .database import DreamDatabase
 from .models import DreamInput, DreamRecord, SymbolResponse
-from .symbol_generator import SymbolGenerator
+from .symbol_generator import AISymbolGenerator, SymbolGenerator
 
 app = FastAPI(
     title="Dream Interpreter API",
@@ -14,10 +20,27 @@ app = FastAPI(
     version="0.1.0",
 )
 
-# Initialize components
-analyser = Dreamanalyser()
-symbol_generator = SymbolGenerator()
+# Both variants are kept ready at startup.
+# AI instances are set to None when the required API key is absent.
+_legacy_analyser = Dreamanalyser()
+_llm_analyser = LLMDreamanalyser() if os.getenv("ANTHROPIC_API_KEY") else None
+_legacy_symbols = SymbolGenerator()
+_ai_symbols = AISymbolGenerator() if os.getenv("OPENAI_API_KEY") else None
 database = DreamDatabase()
+
+
+def _select_analyser(mode: str):
+    """Return the appropriate analyser for the requested mode."""
+    if mode == "legacy" or _llm_analyser is None:
+        return _legacy_analyser
+    return _llm_analyser
+
+
+def _select_symbol_generator(mode: str):
+    """Return the appropriate symbol generator for the requested mode."""
+    if mode == "legacy" or _ai_symbols is None:
+        return _legacy_symbols
+    return _ai_symbols
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -32,12 +55,26 @@ async def root():
             body { font-family: Arial, sans-serif; margin: 40px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); }
             .container { max-width: 800px; margin: 0 auto; background: white; padding: 30px; border-radius: 10px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); }
             h1 { color: #333; text-align: center; margin-bottom: 30px; }
-            textarea { width: 100%; height: 120px; margin: 10px 0; padding: 10px; border: 2px solid #ddd; border-radius: 5px; }
+            textarea { width: 100%; height: 120px; margin: 10px 0; padding: 10px; border: 2px solid #ddd; border-radius: 5px; box-sizing: border-box; }
             button { background: #667eea; color: white; border: none; padding: 12px 24px; border-radius: 5px; cursor: pointer; font-size: 16px; }
             button:hover { background: #5a67d8; }
             .result { margin-top: 20px; padding: 20px; background: #f8f9fa; border-radius: 5px; }
             .symbol img { max-width: 300px; border: 2px solid #ddd; border-radius: 10px; }
             .coordinates { font-family: monospace; background: #e2e8f0; padding: 10px; border-radius: 5px; }
+            .controls { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-top: 10px; }
+            .mode-toggle { display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: #f0f4ff; border-radius: 8px; border: 1px solid #e0e7ff; }
+            .switch { position: relative; display: inline-block; width: 52px; height: 26px; flex-shrink: 0; }
+            .switch input { opacity: 0; width: 0; height: 0; }
+            .slider { position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0; background: #cbd5e0; transition: .3s; border-radius: 26px; }
+            .slider:before { position: absolute; content: ""; height: 20px; width: 20px; left: 3px; bottom: 3px; background: white; transition: .3s; border-radius: 50%; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
+            input:checked + .slider { background: #667eea; }
+            input:checked + .slider:before { transform: translateX(26px); }
+            .mode-label { font-weight: 600; font-size: 14px; color: #4a5568; transition: color .2s; }
+            .mode-desc { color: #888; font-size: 12px; }
+            .badge { font-size: 11px; padding: 2px 8px; border-radius: 10px; font-weight: 600; vertical-align: middle; margin-left: 4px; }
+            .badge-ai { background: #667eea; color: white; }
+            .badge-classic { background: #a0aec0; color: white; }
+            .loading { color: #667eea; font-style: italic; }
         </style>
     </head>
     <body>
@@ -48,19 +85,30 @@ async def root():
                 <li><strong>Upper/Downer</strong>: Emotional valence of your dream</li>
                 <li><strong>Static/Dynamic</strong>: Energy level and activity in your dream</li>
             </ul>
-            
+
             <textarea id="dreamText" placeholder="Enter your dream here... (e.g., 'I was flying over a beautiful landscape, feeling free and joyful...')"></textarea>
-            <br>
-            <input type="text" id="userId" placeholder="Your name (optional)" style="width: 200px; padding: 10px; margin-right: 10px; border: 2px solid #ddd; border-radius: 5px;">
-            <button onclick="analyzeDream()">Analyze Dream</button>
-            
+
+            <div class="controls">
+                <input type="text" id="userId" placeholder="Your name (optional)" style="width: 200px; padding: 10px; border: 2px solid #ddd; border-radius: 5px;">
+                <div class="mode-toggle">
+                    <span class="mode-label" id="classicLabel" style="color:#667eea;">Classic</span>
+                    <label class="switch">
+                        <input type="checkbox" id="aiMode" onchange="updateModeLabel()">
+                        <span class="slider"></span>
+                    </label>
+                    <span class="mode-label" id="aiLabel">AI</span>
+                    <span class="mode-desc" id="modeDesc">TextBlob + matplotlib</span>
+                </div>
+                <button onclick="analyzeDream()">Analyze Dream</button>
+            </div>
+
             <div id="result" class="result" style="display:none;">
                 <h3>Dream Analysis</h3>
                 <div id="analysis"></div>
                 <div id="symbolContainer" class="symbol"></div>
                 <button onclick="getUserStats()" style="margin-top: 10px;">View My Dream Statistics</button>
             </div>
-            
+
             <div id="stats" style="display:none; margin-top: 20px; padding: 20px; background: #e8f4fd; border-radius: 5px;">
                 <h3>Your Dream Statistics</h3>
                 <div id="statsContent"></div>
@@ -68,24 +116,33 @@ async def root():
         </div>
 
         <script>
+        function updateModeLabel() {
+            const ai = document.getElementById('aiMode').checked;
+            document.getElementById('modeDesc').textContent = ai ? 'Claude + DALL\u00b7E 3' : 'TextBlob + matplotlib';
+            document.getElementById('aiLabel').style.color    = ai ? '#667eea' : '#4a5568';
+            document.getElementById('classicLabel').style.color = ai ? '#4a5568' : '#667eea';
+        }
+
         async function analyzeDream() {
             const dreamText = document.getElementById('dreamText').value;
-            const userId = document.getElementById('userId').value || 'anonymous';
-            
-            if (!dreamText.trim()) {
-                alert('Please enter your dream first!');
-                return;
-            }
+            const userId    = document.getElementById('userId').value || 'anonymous';
+            const aiMode    = document.getElementById('aiMode').checked;
+            const mode      = aiMode ? 'ai' : 'legacy';
+
+            if (!dreamText.trim()) { alert('Please enter your dream first!'); return; }
 
             try {
                 const response = await fetch('/analyze-dream', {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({dream_text: dreamText, user_id: userId})
+                    body: JSON.stringify({dream_text: dreamText, user_id: userId, mode: mode})
                 });
-                
                 const data = await response.json();
-                
+
+                const analyserBadge = aiMode
+                    ? '<span class="badge badge-ai">Claude</span>'
+                    : '<span class="badge badge-classic">Classic</span>';
+
                 document.getElementById('analysis').innerHTML = `
                     <div class="coordinates">
                         <strong>Coordinates:</strong> (${data.analysis.static_dynamic_score.toFixed(2)}, ${data.analysis.upper_downer_score.toFixed(2)})
@@ -93,20 +150,28 @@ async def root():
                     <p><strong>Emotional Tone:</strong> ${data.analysis.upper_downer_score > 0 ? 'Upper' : 'Downer'} (${data.analysis.upper_downer_score.toFixed(2)})</p>
                     <p><strong>Energy Level:</strong> ${data.analysis.static_dynamic_score > 0 ? 'Dynamic' : 'Static'} (${data.analysis.static_dynamic_score.toFixed(2)})</p>
                     <p><strong>Confidence:</strong> ${(data.analysis.confidence * 100).toFixed(1)}%</p>
-                    <p><strong>Keywords:</strong> ${data.analysis.keywords.join(', ') || 'None identified'}</p>
+                    <p><strong>Keywords</strong> ${analyserBadge}: ${data.analysis.keywords.join(', ') || 'None identified'}</p>
                 `;
-                
-                const symbolResponse = await fetch(`/generate-symbol/${userId}`);
+
+                const symbolContainer = document.getElementById('symbolContainer');
+                symbolContainer.innerHTML = aiMode
+                    ? '<p class="loading">\u2728 Generating symbol with DALL\u00b7E\u00a03, this may take ~20 seconds\u2026</p>'
+                    : '<p class="loading">Generating symbol\u2026</p>';
+                document.getElementById('result').style.display = 'block';
+
+                const symbolResponse = await fetch(`/generate-symbol/${userId}?mode=${mode}`);
                 const symbolData = await symbolResponse.json();
-                
-                document.getElementById('symbolContainer').innerHTML = `
-                    <h4>Your Personal Dream Symbol</h4>
+
+                const symbolBadge = aiMode
+                    ? '<span class="badge badge-ai">DALL\u00b7E\u00a03</span>'
+                    : '<span class="badge badge-classic">Classic</span>';
+
+                symbolContainer.innerHTML = `
+                    <h4>Your Personal Dream Symbol ${symbolBadge}</h4>
                     <img src="data:image/png;base64,${symbolData.symbol_base64}" alt="Dream Symbol">
                     <p><em>This symbol evolves as you add more dreams (${symbolData.dream_count} dreams analyzed)</em></p>
                 `;
-                
-                document.getElementById('result').style.display = 'block';
-                
+
             } catch (error) {
                 alert('Error analyzing dream: ' + error.message);
             }
@@ -114,11 +179,9 @@ async def root():
 
         async function getUserStats() {
             const userId = document.getElementById('userId').value || 'anonymous';
-            
             try {
                 const response = await fetch(`/user-stats/${userId}`);
                 const stats = await response.json();
-                
                 document.getElementById('statsContent').innerHTML = `
                     <p><strong>Total Dreams:</strong> ${stats.total_dreams}</p>
                     <p><strong>Average Emotional Score:</strong> ${stats.average_emotional_score}</p>
@@ -126,9 +189,7 @@ async def root():
                     <p><strong>Average Confidence:</strong> ${(stats.average_confidence * 100).toFixed(1)}%</p>
                     <p><strong>Dominant Pattern:</strong> ${stats.dominant_quadrant}</p>
                 `;
-                
                 document.getElementById('stats').style.display = 'block';
-                
             } catch (error) {
                 alert('Error fetching stats: ' + error.message);
             }
@@ -144,12 +205,14 @@ async def root():
 async def analyze_dream(dream_input: DreamInput):
     """Analyze a dream and store the results."""
     try:
-        # Analyze the dream
-        analysis = analyser.analyze_dream(dream_input.dream_text)
+        selected = _select_analyser(dream_input.mode)
+        if inspect.iscoroutinefunction(selected.analyze_dream):
+            analysis = await selected.analyze_dream(dream_input.dream_text)
+        else:
+            analysis = selected.analyze_dream(dream_input.dream_text)
 
-        # Create and store dream record
         dream_record = DreamRecord(
-            id="",  # Will be set by database
+            id="",
             dream_text=dream_input.dream_text,
             user_id=dream_input.user_id,
             analysis=analysis,
@@ -166,13 +229,16 @@ async def analyze_dream(dream_input: DreamInput):
 
 
 @app.get("/generate-symbol/{user_id}")
-async def generate_symbol(user_id: str) -> SymbolResponse:
+async def generate_symbol(user_id: str, mode: str = "auto") -> SymbolResponse:
     """Generate a symbol based on all user dreams."""
     try:
         user_dreams = database.get_user_dreams(user_id)
-        symbol_base64 = symbol_generator.generate_symbol(user_dreams)
+        selected = _select_symbol_generator(mode)
+        if inspect.iscoroutinefunction(selected.generate_symbol):
+            symbol_base64 = await selected.generate_symbol(user_dreams)
+        else:
+            symbol_base64 = selected.generate_symbol(user_dreams)
 
-        # Get average coordinates for the latest position
         if user_dreams:
             latest_dream = user_dreams[-1]
             coordinates = (

--- a/dream_interpreter/models.py
+++ b/dream_interpreter/models.py
@@ -9,6 +9,10 @@ class DreamInput(BaseModel):
 
     dream_text: str = Field(..., min_length=10, description="The dream description")
     user_id: Optional[str] = Field(default="anonymous", description="User identifier")
+    mode: str = Field(
+        default="auto",
+        description="Analysis mode: 'auto' (use AI if available), 'ai', or 'legacy'",
+    )
 
 
 class DreamAnalysis(BaseModel):

--- a/dream_interpreter/symbol_generator.py
+++ b/dream_interpreter/symbol_generator.py
@@ -47,11 +47,28 @@ class AISymbolGenerator:  # pylint: disable=too-few-public-methods
         if not dreams:
             return self._legacy.generate_symbol(dreams)
 
-        latest = dreams[-1]
+        # Average scores across all dreams so the symbol reflects cumulative history.
+        avg_upper_downer = sum(d.analysis.upper_downer_score for d in dreams) / len(
+            dreams
+        )
+        avg_static_dynamic = sum(d.analysis.static_dynamic_score for d in dreams) / len(
+            dreams
+        )
+
+        # Aggregate keywords most-recent-first so newer dreams take priority in the
+        # 5-keyword prompt slot when the user has many dreams.
+        seen: set = set()
+        all_keywords: List[str] = []
+        for dream in reversed(dreams):
+            for kw in dream.analysis.keywords:
+                if kw not in seen:
+                    seen.add(kw)
+                    all_keywords.append(kw)
+
         prompt = self._build_image_prompt(
-            latest.analysis.keywords,
-            latest.analysis.upper_downer_score,
-            latest.analysis.static_dynamic_score,
+            all_keywords,
+            avg_upper_downer,
+            avg_static_dynamic,
             len(dreams),
         )
 

--- a/dream_interpreter/symbol_generator.py
+++ b/dream_interpreter/symbol_generator.py
@@ -1,28 +1,120 @@
-import matplotlib
-
-matplotlib.use("Agg")
-
+"""Symbol generation using either DALL-E 3 or a legacy matplotlib fallback."""
 import base64
 import io
 import logging
 from typing import List, Tuple
 
-import matplotlib.patches as patches
-import matplotlib.pyplot as plt
-import numpy as np
-from PIL import Image as PILImage
-from PIL import ImageDraw
+import matplotlib
 
-from .models import DreamRecord
+matplotlib.use("Agg")  # Must be called before importing pyplot
+import matplotlib.patches as patches  # pylint: disable=wrong-import-position
+import matplotlib.pyplot as plt  # pylint: disable=wrong-import-position
+import numpy as np  # pylint: disable=wrong-import-position
+from openai import AsyncOpenAI  # pylint: disable=wrong-import-position
+from PIL import Image as PILImage  # pylint: disable=wrong-import-position
+from PIL import ImageDraw  # pylint: disable=wrong-import-position
+
+from .models import DreamRecord  # pylint: disable=wrong-import-position
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-class SymbolGenerator:
-    """Generates evolving symbols based on dream analysis."""
+class AISymbolGenerator:  # pylint: disable=too-few-public-methods
+    """Generates dream symbols using DALL-E 3 image generation."""
+
+    def __init__(self, openai_client: AsyncOpenAI = None):
+        """Initialise the generator.
+
+        Args:
+            openai_client: Optional pre-built AsyncOpenAI client (useful for testing).
+        """
+        self._client = openai_client or AsyncOpenAI()
+        self._legacy = LegacySymbolGenerator()
+
+    async def generate_symbol(self, dreams: List[DreamRecord]) -> str:
+        """Generate a DALL-E 3 image symbol based on the user's dreams.
+
+        Falls back to the legacy matplotlib generator when the dream list is
+        empty or if the OpenAI API call fails.
+
+        Args:
+            dreams: All dream records for the user.
+
+        Returns:
+            Base64-encoded PNG string.
+        """
+        if not dreams:
+            return self._legacy.generate_symbol(dreams)
+
+        latest = dreams[-1]
+        prompt = self._build_image_prompt(
+            latest.analysis.keywords,
+            latest.analysis.upper_downer_score,
+            latest.analysis.static_dynamic_score,
+            len(dreams),
+        )
+
+        try:
+            response = await self._client.images.generate(
+                model="dall-e-3",
+                prompt=prompt,
+                size="1024x1024",
+                response_format="b64_json",
+                n=1,
+            )
+            return response.data[0].b64_json
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.error("AI symbol generation failed, falling back to legacy: %s", e)
+            return self._legacy.generate_symbol(dreams)
+
+    def _build_image_prompt(
+        self,
+        keywords: List[str],
+        upper_downer: float,
+        static_dynamic: float,
+        dream_count: int,
+    ) -> str:
+        """Build a DALL-E prompt from the dream's scores and keywords.
+
+        Args:
+            keywords: Significant dream elements extracted by the analyser.
+            upper_downer: Emotional valence score (-1 to 1).
+            static_dynamic: Energy level score (-1 to 1).
+            dream_count: Total dreams logged by this user.
+
+        Returns:
+            A descriptive prompt string for DALL-E 3.
+        """
+        tone = (
+            "luminous and uplifting"
+            if upper_downer > 0.3
+            else (
+                "shadowy and melancholic"
+                if upper_downer < -0.3
+                else "mysterious and neutral"
+            )
+        )
+        energy = (
+            "swirling and kinetic"
+            if static_dynamic > 0.3
+            else ("still and contemplative" if static_dynamic < -0.3 else "balanced")
+        )
+        keyword_clause = f"incorporating {', '.join(keywords[:5])}" if keywords else ""
+        complexity = f"complexity level {min(dream_count, 10)}/10"
+
+        return (
+            f"A symbolic mandala-like dream artwork, {tone}, {energy}, "
+            f"{keyword_clause}. {complexity}. "
+            "Digital art, intricate, dreamlike, no text."
+        )
+
+
+class LegacySymbolGenerator:
+    """Generates evolving symbols based on dream analysis using matplotlib."""
 
     def __init__(self):
+        """Initialise colour palettes."""
         self.colors = {
             "upper": [
                 "#FFD700",
@@ -41,37 +133,42 @@ class SymbolGenerator:
         }
 
     def generate_symbol(self, dreams: List[DreamRecord]) -> str:
-        """Generate a symbol based on all user dreams."""
+        """Generate a symbol based on all user dreams.
+
+        Args:
+            dreams: All dream records for the user.
+
+        Returns:
+            Base64-encoded PNG string.
+        """
         try:
-            logger.info(f"Starting symbol generation for {len(dreams)} dreams")
+            logger.info("Starting symbol generation for %s dreams", len(dreams))
 
             if not dreams:
                 logger.warning("No dreams provided, generating base symbol.")
                 return self._create_base_symbol()
 
-            # Calculate average position and create symbol
             avg_x, avg_y = self._calculate_average_position(dreams)
-            symbol_complexity = min(len(dreams), 10)  # Cap complexity at 10 dreams
+            symbol_complexity = min(len(dreams), 10)
 
             logger.info(
-                f"Average position: ({avg_x:.2f}, {avg_y:.2f}), Complexity: {symbol_complexity}"
+                "Average position: (%.2f, %.2f), Complexity: %s",
+                avg_x,
+                avg_y,
+                symbol_complexity,
             )
 
-            # Create the symbol
             fig, ax = plt.subplots(1, 1, figsize=(6, 6))
             ax.set_xlim(-1.5, 1.5)
             ax.set_ylim(-1.5, 1.5)
             ax.set_aspect("equal")
             ax.axis("off")
 
-            # Set background color based on dominant emotional tone
             bg_color = self._get_background_color(avg_y)
             fig.patch.set_facecolor(bg_color)
 
-            # Draw the evolving symbol
             self._draw_symbol_layers(ax, dreams, avg_x, avg_y, symbol_complexity)
 
-            # Convert to base64
             buffer = io.BytesIO()
             plt.savefig(
                 buffer,
@@ -89,8 +186,8 @@ class SymbolGenerator:
             logger.info("Symbol generation completed successfully.")
             return image_base64
 
-        except Exception as e:
-            logger.error(f"Error generating symbol: {e}")
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.error("Error generating symbol: %s", e)
             return self._create_error_symbol()
 
     def _calculate_average_position(
@@ -99,23 +196,20 @@ class SymbolGenerator:
         """Calculate the average position of all dreams."""
         x_coords = [dream.analysis.static_dynamic_score for dream in dreams]
         y_coords = [dream.analysis.upper_downer_score for dream in dreams]
-
         return np.mean(x_coords), np.mean(y_coords)
 
     def _get_background_color(self, avg_y: float) -> str:
         """Get background color based on emotional tone."""
         if avg_y > 0.3:
             return "#FFF8DC"  # Cornsilk (light, positive)
-        elif avg_y < -0.3:
+        if avg_y < -0.3:
             return "#2F2F2F"  # Dark gray (darker, negative)
-        else:
-            return "#F5F5F5"  # Light gray (neutral)
+        return "#F5F5F5"  # Light gray (neutral)
 
     def _draw_symbol_layers(
         self, ax, dreams: List[DreamRecord], avg_x: float, avg_y: float, complexity: int
     ):
         """Draw the layered symbol based on dreams."""
-        # Base circle representing the dreamer's core
         try:
             base_color = self._get_primary_color(avg_x, avg_y)
             base_circle = patches.Circle(
@@ -128,33 +222,23 @@ class SymbolGenerator:
             )
             ax.add_patch(base_circle)
 
-            # Add layers for each dream (up to complexity limit)
             for i, dream in enumerate(dreams[:complexity]):
                 self._add_dream_layer(ax, dream, i, complexity)
 
-            # Add central symbol based on dominant characteristics
             self._add_central_symbol(ax, avg_x, avg_y)
 
-        except Exception as e:
-            logger.error(f"Error drawing symbol layers: {e}")
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.error("Error drawing symbol layers: %s", e)
 
     def _get_primary_color(self, x: float, y: float) -> str:
         """Get primary color based on coordinates."""
         try:
-            if y > 0:  # Upper
-                if x > 0:  # Dynamic upper
-                    return self.colors["upper"][0]  # Gold
-                else:  # Static upper
-                    return self.colors["upper"][3]  # Turquoise
-            else:  # Downer
-                if x > 0:  # Dynamic downer
-                    return self.colors["downer"][0]  # Purple
-                else:  # Static downer
-                    return self.colors["downer"][2]  # Navy
-
-        except Exception as e:
-            logger.error(f"Error selecting primary color: {e}")
-            return "#808080"  # Fallback to gray
+            if y > 0:
+                return self.colors["upper"][0] if x > 0 else self.colors["upper"][3]
+            return self.colors["downer"][0] if x > 0 else self.colors["downer"][2]
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.error("Error selecting primary color: %s", e)
+            return "#808080"
 
     def _add_dream_layer(
         self, ax, dream: DreamRecord, layer_index: int, total_layers: int
@@ -164,16 +248,14 @@ class SymbolGenerator:
             x = dream.analysis.static_dynamic_score
             y = dream.analysis.upper_downer_score
 
-            # Calculate position around the base circle
             angle = (2 * np.pi * layer_index) / total_layers
-            radius = 0.5 + (layer_index * 0.1)  # Expanding outward
+            radius = 0.5 + (layer_index * 0.1)
 
-            pos_x = radius * np.cos(angle) * 0.5  # Scale down
+            pos_x = radius * np.cos(angle) * 0.5
             pos_y = radius * np.sin(angle) * 0.5
 
-            # Choose shape based on dream characteristics
-            if abs(x) > abs(y):  # More dynamic/static than upper/downer
-                if x > 0:  # Dynamic - use triangles
+            if abs(x) > abs(y):
+                if x > 0:
                     triangle = patches.RegularPolygon(
                         (pos_x, pos_y),
                         3,
@@ -182,7 +264,7 @@ class SymbolGenerator:
                         alpha=0.7,
                     )
                     ax.add_patch(triangle)
-                else:  # Static - use squares
+                else:
                     square = patches.Rectangle(
                         (pos_x - 0.05, pos_y - 0.05),
                         0.1,
@@ -191,7 +273,7 @@ class SymbolGenerator:
                         alpha=0.7,
                     )
                     ax.add_patch(square)
-            else:  # More emotional than dynamic
+            else:
                 circle = patches.Circle(
                     (pos_x, pos_y),
                     0.05,
@@ -199,30 +281,24 @@ class SymbolGenerator:
                     alpha=0.7,
                 )
                 ax.add_patch(circle)
-        except Exception as e:
-            logger.error(f"Error adding dream layer: {layer_index}: {str(e)}")
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.error("Error adding dream layer %s: %s", layer_index, e)
 
     def _get_dream_color(self, x: float, y: float) -> str:
         """Get color for individual dream based on its coordinates."""
         try:
-            if y > 0:
-                colors = self.colors["upper"]
-            else:
-                colors = self.colors["downer"]
-
-            # Pick color based on intensity
+            colors = self.colors["upper"] if y > 0 else self.colors["downer"]
             intensity = (abs(y) + abs(x)) / 2
             color_index = min(int(intensity * len(colors)), len(colors) - 1)
             return colors[color_index]
-        except Exception as e:
-            logger.error(f"Error selecting dream color: {e}")
-            return "#808080"  # Fallback to gray
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.error("Error selecting dream color: %s", e)
+            return "#808080"
 
     def _add_central_symbol(self, ax, avg_x: float, avg_y: float):
         """Add a central symbol representing the overall dream pattern."""
         try:
-            if avg_y > 0.5:  # Very positive
-                # Add a star
+            if avg_y > 0.5:
                 star = patches.RegularPolygon(
                     (0, 0),
                     5,
@@ -232,21 +308,19 @@ class SymbolGenerator:
                     linewidth=2,
                 )
                 ax.add_patch(star)
-            elif avg_y < -0.5:  # Very negative
-                # Add a darker center
+            elif avg_y < -0.5:
                 center = patches.Circle((0, 0), 0.1, facecolor="black", alpha=0.8)
                 ax.add_patch(center)
 
-            if abs(avg_x) > 0.5:  # Very dynamic or static
-                # Add radiating lines
+            if abs(avg_x) > 0.5:
                 for angle in np.linspace(0, 2 * np.pi, 8, endpoint=False):
-                    line_length = 0.2 if avg_x > 0 else 0.15  # Longer lines for dynamic
+                    line_length = 0.2 if avg_x > 0 else 0.15
                     end_x = line_length * np.cos(angle)
                     end_y = line_length * np.sin(angle)
                     ax.plot([0, end_x], [0, end_y], "white", linewidth=2, alpha=0.8)
 
-        except Exception as e:
-            logger.error(f"Error adding central symbol: {e}")
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.error("Error adding central symbol: %s", e)
 
     def _create_base_symbol(self) -> str:
         """Create a base symbol for new users."""
@@ -258,7 +332,6 @@ class SymbolGenerator:
             ax.axis("off")
             fig.patch.set_facecolor("#F5F5F5")
 
-            # Simple circle for new dreamers
             circle = patches.Circle(
                 (0, 0),
                 0.3,
@@ -269,7 +342,6 @@ class SymbolGenerator:
             )
             ax.add_patch(circle)
 
-            # Convert to base64
             buffer = io.BytesIO()
             plt.savefig(
                 buffer,
@@ -283,27 +355,24 @@ class SymbolGenerator:
 
             buffer.seek(0)
             return base64.b64encode(buffer.getvalue()).decode("utf-8")
-        except Exception as e:
-            logger.error(f"Error creating base symbol: {e}")
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.error("Error creating base symbol: %s", e)
             return self._create_error_symbol()
 
     def _create_error_symbol(self) -> str:
-        """Create a simple error symbol when matplotlib fails."""
+        """Create a minimal fallback symbol when matplotlib fails."""
         try:
-            # Create a minimal 100x100 white image with a simple pattern
-
             img = PILImage.new("RGB", (100, 100), color="white")
             draw = ImageDraw.Draw(img)
-
-            # Draw a simple circle
             draw.ellipse([25, 25, 75, 75], fill="lightblue", outline="black")
 
-            # Convert to base64
             buffer = io.BytesIO()
             img.save(buffer, format="PNG")
             buffer.seek(0)
-
             return base64.b64encode(buffer.getvalue()).decode("utf-8")
-        except Exception:
-            # Last resort: return a tiny transparent image
+        except Exception:  # pylint: disable=broad-exception-caught
             return "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+
+
+# Backward-compatibility alias — existing imports of SymbolGenerator still work.
+SymbolGenerator = LegacySymbolGenerator

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,6 +13,31 @@ files = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.40.0"
+description = "The official Python library for the anthropic API"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "anthropic-0.40.0-py3-none-any.whl", hash = "sha256:442028ae8790ff9e3b6f8912043918755af1230d193904ae2ef78cc22995280c"},
+    {file = "anthropic-0.40.0.tar.gz", hash = "sha256:3efeca6d9e97813f93ed34322c6c7ea2279bf0824cd0aa71b59ce222665e2b87"},
+]
+
+[package.dependencies]
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+httpx = ">=0.23.0,<1"
+jiter = ">=0.4.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+typing-extensions = ">=4.7,<5"
+
+[package.extras]
+bedrock = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
+vertex = ["google-auth (>=2,<3)"]
+
+[[package]]
 name = "anyio"
 version = "3.7.1"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
@@ -102,7 +127,7 @@ version = "2025.8.3"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5"},
     {file = "certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407"},
@@ -374,6 +399,18 @@ graph = ["objgraph (>=1.7.2)"]
 profile = ["gprof2dot (>=2022.7.29)"]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+description = "Distro - an OS platform information API"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
+    {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 description = "Backport of PEP 654 (exception groups)"
@@ -512,7 +549,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -534,7 +571,7 @@ version = "0.25.2"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "httpx-0.25.2-py3-none-any.whl", hash = "sha256:a05d3d052d9b2dfce0e3896636467f8a5342fb2b902c819428e1ac65413ca118"},
     {file = "httpx-0.25.2.tar.gz", hash = "sha256:8b8fcaa0c8ea7b05edd69a094e63a2094c4efcb48129fb757361bc423c0ad9e8"},
@@ -619,6 +656,118 @@ files = [
 [package.extras]
 colors = ["colorama"]
 plugins = ["setuptools"]
+
+[[package]]
+name = "jiter"
+version = "0.13.0"
+description = "Fast iterable JSON parser."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "jiter-0.13.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2ffc63785fd6c7977defe49b9824ae6ce2b2e2b77ce539bdaf006c26da06342e"},
+    {file = "jiter-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4a638816427006c1e3f0013eb66d391d7a3acda99a7b0cf091eff4497ccea33a"},
+    {file = "jiter-0.13.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19928b5d1ce0ff8c1ee1b9bdef3b5bfc19e8304f1b904e436caf30bc15dc6cf5"},
+    {file = "jiter-0.13.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:309549b778b949d731a2f0e1594a3f805716be704a73bf3ad9a807eed5eb5721"},
+    {file = "jiter-0.13.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bcdabaea26cb04e25df3103ce47f97466627999260290349a88c8136ecae0060"},
+    {file = "jiter-0.13.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a377af27b236abbf665a69b2bdd680e3b5a0bd2af825cd3b81245279a7606c"},
+    {file = "jiter-0.13.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe49d3ff6db74321f144dff9addd4a5874d3105ac5ba7c5b77fac099cfae31ae"},
+    {file = "jiter-0.13.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2113c17c9a67071b0f820733c0893ed1d467b5fcf4414068169e5c2cabddb1e2"},
+    {file = "jiter-0.13.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ab1185ca5c8b9491b55ebf6c1e8866b8f68258612899693e24a92c5fdb9455d5"},
+    {file = "jiter-0.13.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9621ca242547edc16400981ca3231e0c91c0c4c1ab8573a596cd9bb3575d5c2b"},
+    {file = "jiter-0.13.0-cp310-cp310-win32.whl", hash = "sha256:a7637d92b1c9d7a771e8c56f445c7f84396d48f2e756e5978840ecba2fac0894"},
+    {file = "jiter-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:c1b609e5cbd2f52bb74fb721515745b407df26d7b800458bd97cb3b972c29e7d"},
+    {file = "jiter-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ea026e70a9a28ebbdddcbcf0f1323128a8db66898a06eaad3a4e62d2f554d096"},
+    {file = "jiter-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66aa3e663840152d18cc8ff1e4faad3dd181373491b9cfdc6004b92198d67911"},
+    {file = "jiter-0.13.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3524798e70655ff19aec58c7d05adb1f074fecff62da857ea9be2b908b6d701"},
+    {file = "jiter-0.13.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec7e287d7fbd02cb6e22f9a00dd9c9cd504c40a61f2c61e7e1f9690a82726b4c"},
+    {file = "jiter-0.13.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:47455245307e4debf2ce6c6e65a717550a0244231240dcf3b8f7d64e4c2f22f4"},
+    {file = "jiter-0.13.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee9da221dca6e0429c2704c1b3655fe7b025204a71d4d9b73390c759d776d165"},
+    {file = "jiter-0.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24ab43126d5e05f3d53a36a8e11eb2f23304c6c1117844aaaf9a0aa5e40b5018"},
+    {file = "jiter-0.13.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9da38b4fedde4fb528c740c2564628fbab737166a0e73d6d46cb4bb5463ff411"},
+    {file = "jiter-0.13.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0b34c519e17658ed88d5047999a93547f8889f3c1824120c26ad6be5f27b6cf5"},
+    {file = "jiter-0.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d2a6394e6af690d462310a86b53c47ad75ac8c21dc79f120714ea449979cb1d3"},
+    {file = "jiter-0.13.0-cp311-cp311-win32.whl", hash = "sha256:0f0c065695f616a27c920a56ad0d4fc46415ef8b806bf8fc1cacf25002bd24e1"},
+    {file = "jiter-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:0733312953b909688ae3c2d58d043aa040f9f1a6a75693defed7bc2cc4bf2654"},
+    {file = "jiter-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:5d9b34ad56761b3bf0fbe8f7e55468704107608512350962d3317ffd7a4382d5"},
+    {file = "jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663"},
+    {file = "jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505"},
+    {file = "jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152"},
+    {file = "jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726"},
+    {file = "jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0"},
+    {file = "jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089"},
+    {file = "jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93"},
+    {file = "jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08"},
+    {file = "jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2"},
+    {file = "jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228"},
+    {file = "jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394"},
+    {file = "jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92"},
+    {file = "jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9"},
+    {file = "jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf"},
+    {file = "jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a"},
+    {file = "jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb"},
+    {file = "jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2"},
+    {file = "jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f"},
+    {file = "jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159"},
+    {file = "jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663"},
+    {file = "jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa"},
+    {file = "jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820"},
+    {file = "jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68"},
+    {file = "jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72"},
+    {file = "jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc"},
+    {file = "jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b"},
+    {file = "jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10"},
+    {file = "jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef"},
+    {file = "jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6"},
+    {file = "jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d"},
+    {file = "jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d"},
+    {file = "jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0"},
+    {file = "jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91"},
+    {file = "jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09"},
+    {file = "jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607"},
+    {file = "jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66"},
+    {file = "jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2"},
+    {file = "jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad"},
+    {file = "jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d"},
+    {file = "jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df"},
+    {file = "jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d"},
+    {file = "jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6"},
+    {file = "jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f"},
+    {file = "jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d"},
+    {file = "jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0"},
+    {file = "jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40"},
+    {file = "jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202"},
+    {file = "jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0"},
+    {file = "jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95"},
+    {file = "jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59"},
+    {file = "jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe"},
+    {file = "jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939"},
+    {file = "jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9"},
+    {file = "jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6"},
+    {file = "jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8"},
+    {file = "jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024"},
+    {file = "jiter-0.13.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:4397ee562b9f69d283e5674445551b47a5e8076fdde75e71bfac5891113dc543"},
+    {file = "jiter-0.13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7f90023f8f672e13ea1819507d2d21b9d2d1c18920a3b3a5f1541955a85b5504"},
+    {file = "jiter-0.13.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed0240dd1536a98c3ab55e929c60dfff7c899fecafcb7d01161b21a99fc8c363"},
+    {file = "jiter-0.13.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6207fc61c395b26fffdcf637a0b06b4326f35bfa93c6e92fe1a166a21aeb6731"},
+    {file = "jiter-0.13.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00203f47c214156df427b5989de74cb340c65c8180d09be1bf9de81d0abad599"},
+    {file = "jiter-0.13.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c26ad6967c9dcedf10c995a21539c3aa57d4abad7001b7a84f621a263a6b605"},
+    {file = "jiter-0.13.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a576f5dce9ac7de5d350b8e2f552cf364f32975ed84717c35379a51c7cb198bd"},
+    {file = "jiter-0.13.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b22945be8425d161f2e536cdae66da300b6b000f1c0ba3ddf237d1bfd45d21b8"},
+    {file = "jiter-0.13.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6eeb7db8bc77dc20476bc2f7407a23dbe3d46d9cc664b166e3d474e1c1de4baa"},
+    {file = "jiter-0.13.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:19cd6f85e1dc090277c3ce90a5b7d96f32127681d825e71c9dce28788e39fc0c"},
+    {file = "jiter-0.13.0-cp39-cp39-win32.whl", hash = "sha256:dc3ce84cfd4fa9628fe62c4f85d0d597a4627d4242cfafac32a12cc1455d00f7"},
+    {file = "jiter-0.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:9ffda299e417dc83362963966c50cb76d42da673ee140de8a8ac762d4bb2378b"},
+    {file = "jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b1cbfa133241d0e6bdab48dcdc2604e8ba81512f6bbd68ec3e8e1357dd3c316c"},
+    {file = "jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:db367d8be9fad6e8ebbac4a7578b7af562e506211036cba2c06c3b998603c3d2"},
+    {file = "jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45f6f8efb2f3b0603092401dc2df79fa89ccbc027aaba4174d2d4133ed661434"},
+    {file = "jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:597245258e6ad085d064780abfb23a284d418d3e61c57362d9449c6c7317ee2d"},
+    {file = "jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a"},
+    {file = "jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f"},
+    {file = "jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59"},
+    {file = "jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19"},
+    {file = "jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4"},
+]
 
 [[package]]
 name = "joblib"
@@ -917,6 +1066,34 @@ files = [
     {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
     {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
 ]
+
+[[package]]
+name = "openai"
+version = "1.109.1"
+description = "The official Python library for the openai API"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "openai-1.109.1-py3-none-any.whl", hash = "sha256:6bcaf57086cf59159b8e27447e4e7dd019db5d29a438072fbd49c290c7e65315"},
+    {file = "openai-1.109.1.tar.gz", hash = "sha256:d173ed8dbca665892a6db099b4a2dfac624f94d20a93f46eb0b56aae940ed869"},
+]
+
+[package.dependencies]
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+httpx = ">=0.23.0,<1"
+jiter = ">=0.4.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+tqdm = ">4"
+typing-extensions = ">=4.11,<5"
+
+[package.extras]
+aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.8)"]
+datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
+realtime = ["websockets (>=13,<16)"]
+voice-helpers = ["numpy (>=2.0.2)", "sounddevice (>=0.5.1)"]
 
 [[package]]
 name = "packaging"
@@ -1329,6 +1506,21 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61"},
+    {file = "python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
 
 [[package]]
 name = "regex"
@@ -1772,4 +1964,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "982df1729d2f2374a5fae76df455f1d4ba076191f157a5de230d1d194ae1da86"
+content-hash = "3c85ebf97a2a345d1f58bb864f3cefd25be0acad0b3c18427c44e9f888adbc75"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ matplotlib = "^3.7.0"
 pillow = "^10.0.0"
 textblob = "^0.17.1"
 scikit-learn = "^1.3.0"
+anthropic = "^0.40.0"
+python-dotenv = "^1.0.0"
+openai = "^1.30.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"
@@ -28,6 +31,9 @@ pytest-cov = "^7.0.0"
 [tool.black]
 line-length = 88
 target-version = ['py39']
+
+[tool.isort]
+profile = "black"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_analyser.py
+++ b/tests/test_analyser.py
@@ -1,6 +1,9 @@
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
-from dream_interpreter.analyser import Dreamanalyser
+from dream_interpreter.analyser import Dreamanalyser, LLMDreamanalyser
+from dream_interpreter.models import DreamAnalysis
 
 
 class TestDreamanalyser:
@@ -62,3 +65,125 @@ class TestDreamanalyser:
         assert expected_keywords.intersection(
             found_keywords
         ), "Should find relevant keywords"
+
+
+class TestLLMDreamanalyser:
+    """Test cases for the LLMDreamanalyser class."""
+
+    def setup_method(self):
+        """Set up test fixtures with a mock Anthropic client to avoid real API calls."""
+        self.mock_client = MagicMock()
+        self.analyser = LLMDreamanalyser(anthropic_client=self.mock_client)
+
+    def _make_mock_response(
+        self,
+        upper_downer: float = 0.5,
+        static_dynamic: float = 0.5,
+        confidence: float = 0.8,
+        keywords: list = None,
+    ) -> MagicMock:
+        """Build a fake Anthropic tool-use response."""
+        mock_tool_use = MagicMock()
+        mock_tool_use.input = {
+            "upper_downer_score": upper_downer,
+            "static_dynamic_score": static_dynamic,
+            "confidence": confidence,
+            "keywords": keywords or [],
+        }
+        mock_message = MagicMock()
+        mock_message.content = [mock_tool_use]
+        return mock_message
+
+    @pytest.mark.asyncio
+    async def test_analyze_dream_returns_dream_analysis_type(self):
+        """analyze_dream should return a DreamAnalysis instance."""
+        self.mock_client.messages.create = AsyncMock(
+            return_value=self._make_mock_response()
+        )
+        result = await self.analyser.analyze_dream("I was flying through clouds")
+        assert isinstance(result, DreamAnalysis)
+
+    @pytest.mark.asyncio
+    async def test_analyze_dream_maps_tool_output_to_scores(self):
+        """Scores from the API tool response should be passed through unchanged."""
+        self.mock_client.messages.create = AsyncMock(
+            return_value=self._make_mock_response(
+                upper_downer=0.7,
+                static_dynamic=-0.3,
+                confidence=0.9,
+                keywords=["labyrinth", "ouroboros"],
+            )
+        )
+        result = await self.analyser.analyze_dream("I wandered a labyrinth")
+        assert result.upper_downer_score == 0.7
+        assert result.static_dynamic_score == -0.3
+        assert result.confidence == 0.9
+        assert result.keywords == ["labyrinth", "ouroboros"]
+
+    @pytest.mark.asyncio
+    async def test_analyze_dream_passes_dream_text_as_user_message(self):
+        """The dream text should be sent as the user message to the API."""
+        mock_create = AsyncMock(return_value=self._make_mock_response())
+        self.mock_client.messages.create = mock_create
+
+        dream_text = "A very specific dream description for testing"
+        await self.analyser.analyze_dream(dream_text)
+
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["messages"][0]["content"] == dream_text
+
+    @pytest.mark.asyncio
+    async def test_analyze_dream_forces_tool_use(self):
+        """tool_choice should be set to 'any' to prevent free-text responses."""
+        mock_create = AsyncMock(return_value=self._make_mock_response())
+        self.mock_client.messages.create = mock_create
+
+        await self.analyser.analyze_dream("some dream")
+
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["tool_choice"] == {"type": "any"}
+
+    @pytest.mark.asyncio
+    async def test_analyze_dream_uses_zero_temperature(self):
+        """temperature=0 should be set for reproducible results in tests."""
+        mock_create = AsyncMock(return_value=self._make_mock_response())
+        self.mock_client.messages.create = mock_create
+
+        await self.analyser.analyze_dream("some dream")
+
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["temperature"] == 0
+
+    @pytest.mark.asyncio
+    async def test_analyze_dream_score_boundary_negative(self):
+        """Scores at the negative boundary (-1.0) should be accepted."""
+        self.mock_client.messages.create = AsyncMock(
+            return_value=self._make_mock_response(
+                upper_downer=-1.0, static_dynamic=-1.0
+            )
+        )
+        result = await self.analyser.analyze_dream("nightmare")
+        assert result.upper_downer_score == -1.0
+        assert result.static_dynamic_score == -1.0
+
+    @pytest.mark.asyncio
+    async def test_analyze_dream_score_boundary_positive(self):
+        """Scores at the positive boundary (1.0) should be accepted."""
+        self.mock_client.messages.create = AsyncMock(
+            return_value=self._make_mock_response(upper_downer=1.0, static_dynamic=1.0)
+        )
+        result = await self.analyser.analyze_dream("bliss")
+        assert result.upper_downer_score == 1.0
+        assert result.static_dynamic_score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_analyze_dream_accepts_novel_keywords(self):
+        """Keywords not in the legacy word list should be returned without filtering."""
+        novel_keywords = ["ouroboros", "labyrinth", "chrysalis", "doppelganger"]
+        self.mock_client.messages.create = AsyncMock(
+            return_value=self._make_mock_response(keywords=novel_keywords)
+        )
+        result = await self.analyser.analyze_dream(
+            "I encountered an ouroboros inside a labyrinth"
+        )
+        assert result.keywords == novel_keywords

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,203 @@
+from datetime import datetime
+
+from dream_interpreter.database import DreamDatabase
+from dream_interpreter.models import DreamAnalysis, DreamRecord
+
+
+def _make_record(
+    user_id: str = "user1",
+    upper_downer: float = 0.5,
+    static_dynamic: float = 0.5,
+    confidence: float = 0.8,
+) -> DreamRecord:
+    """Create a DreamRecord with sensible defaults for testing."""
+    return DreamRecord(
+        id="placeholder",
+        dream_text="I was flying through golden clouds",
+        user_id=user_id,
+        analysis=DreamAnalysis(
+            upper_downer_score=upper_downer,
+            static_dynamic_score=static_dynamic,
+            confidence=confidence,
+            keywords=["flying"],
+        ),
+        timestamp=datetime(2026, 1, 1, 12, 0, 0),
+    )
+
+
+class TestDreamDatabase:
+    """Test cases for the DreamDatabase class."""
+
+    def setup_method(self):
+        """Set up a fresh database for each test."""
+        self.db = DreamDatabase()
+
+    # ------------------------------------------------------------------
+    # store_dream
+    # ------------------------------------------------------------------
+
+    def test_store_dream_returns_string_id(self):
+        """store_dream should return a non-empty string ID."""
+        dream_id = self.db.store_dream(_make_record())
+        assert isinstance(dream_id, str)
+        assert len(dream_id) > 0
+
+    def test_store_dream_assigns_id_to_record(self):
+        """store_dream should write the generated ID back onto the record."""
+        record = _make_record()
+        dream_id = self.db.store_dream(record)
+        assert record.id == dream_id
+
+    def test_store_dream_returns_unique_ids(self):
+        """Each stored dream should receive a distinct UUID."""
+        ids = {self.db.store_dream(_make_record()) for _ in range(5)}
+        assert len(ids) == 5
+
+    def test_store_dream_indexes_by_user(self):
+        """After storing, the dream ID should appear under the correct user."""
+        record = _make_record(user_id="alice")
+        dream_id = self.db.store_dream(record)
+        assert dream_id in self.db.user_dreams["alice"]
+
+    def test_store_dream_accumulates_multiple_dreams_for_same_user(self):
+        """Storing two dreams for the same user should produce two entries."""
+        self.db.store_dream(_make_record(user_id="bob"))
+        self.db.store_dream(_make_record(user_id="bob"))
+        assert len(self.db.user_dreams["bob"]) == 2
+
+    def test_store_dream_keeps_users_separate(self):
+        """Dreams stored under different user IDs must not bleed into each other."""
+        self.db.store_dream(_make_record(user_id="alice"))
+        self.db.store_dream(_make_record(user_id="bob"))
+        assert len(self.db.user_dreams["alice"]) == 1
+        assert len(self.db.user_dreams["bob"]) == 1
+
+    # ------------------------------------------------------------------
+    # get_dream
+    # ------------------------------------------------------------------
+
+    def test_get_dream_returns_stored_record(self):
+        """get_dream should return the exact record that was stored."""
+        record = _make_record(user_id="alice")
+        dream_id = self.db.store_dream(record)
+        fetched = self.db.get_dream(dream_id)
+        assert fetched is record
+
+    def test_get_dream_returns_none_for_unknown_id(self):
+        """get_dream should return None when the ID does not exist."""
+        assert self.db.get_dream("nonexistent-id") is None
+
+    # ------------------------------------------------------------------
+    # get_user_dreams
+    # ------------------------------------------------------------------
+
+    def test_get_user_dreams_returns_empty_list_for_unknown_user(self):
+        """get_user_dreams should return [] when the user has no dreams stored."""
+        assert self.db.get_user_dreams("ghost") == []
+
+    def test_get_user_dreams_returns_all_dreams_for_user(self):
+        """get_user_dreams should return every dream stored under that user ID."""
+        r1 = _make_record(user_id="carol")
+        r2 = _make_record(user_id="carol")
+        self.db.store_dream(r1)
+        self.db.store_dream(r2)
+        dreams = self.db.get_user_dreams("carol")
+        assert len(dreams) == 2
+        assert r1 in dreams
+        assert r2 in dreams
+
+    def test_get_user_dreams_excludes_other_users(self):
+        """get_user_dreams must not return dreams belonging to a different user."""
+        self.db.store_dream(_make_record(user_id="dave"))
+        self.db.store_dream(_make_record(user_id="eve"))
+        assert len(self.db.get_user_dreams("dave")) == 1
+
+    # ------------------------------------------------------------------
+    # get_user_stats — empty / no dreams
+    # ------------------------------------------------------------------
+
+    def test_get_user_stats_no_dreams_returns_zero_total(self):
+        """get_user_stats should return {total_dreams: 0} for a user with no dreams."""
+        stats = self.db.get_user_stats("nobody")
+        assert stats == {"total_dreams": 0}
+
+    # ------------------------------------------------------------------
+    # get_user_stats — with dreams
+    # ------------------------------------------------------------------
+
+    def test_get_user_stats_total_dreams_count(self):
+        """total_dreams should equal the number of stored dreams."""
+        for _ in range(3):
+            self.db.store_dream(_make_record(user_id="frank"))
+        assert self.db.get_user_stats("frank")["total_dreams"] == 3
+
+    def test_get_user_stats_average_scores_are_rounded(self):
+        """Averages should be rounded to two decimal places."""
+        self.db.store_dream(
+            _make_record(
+                user_id="grace", upper_downer=0.1, static_dynamic=0.2, confidence=0.9
+            )
+        )
+        self.db.store_dream(
+            _make_record(
+                user_id="grace", upper_downer=0.2, static_dynamic=0.3, confidence=0.7
+            )
+        )
+        stats = self.db.get_user_stats("grace")
+        assert stats["average_emotional_score"] == round((0.1 + 0.2) / 2, 2)
+        assert stats["average_dynamic_score"] == round((0.2 + 0.3) / 2, 2)
+        assert stats["average_confidence"] == round((0.9 + 0.7) / 2, 2)
+
+    def test_get_user_stats_single_dream_averages_equal_that_dream(self):
+        """With one dream, each average should equal that dream's score."""
+        self.db.store_dream(
+            _make_record(
+                user_id="henry", upper_downer=0.6, static_dynamic=-0.4, confidence=0.75
+            )
+        )
+        stats = self.db.get_user_stats("henry")
+        assert stats["average_emotional_score"] == 0.6
+        assert stats["average_dynamic_score"] == -0.4
+        assert stats["average_confidence"] == 0.75
+
+    def test_get_user_stats_contains_dominant_quadrant_key(self):
+        """get_user_stats result should always include a dominant_quadrant key."""
+        self.db.store_dream(_make_record(user_id="ida"))
+        stats = self.db.get_user_stats("ida")
+        assert "dominant_quadrant" in stats
+
+    # ------------------------------------------------------------------
+    # _get_dominant_quadrant (tested indirectly via get_user_stats)
+    # ------------------------------------------------------------------
+
+    def test_dominant_quadrant_dynamic_upper(self):
+        """Positive upper_downer and positive static_dynamic → Dynamic Upper."""
+        self.db.store_dream(
+            _make_record(user_id="q1", upper_downer=0.5, static_dynamic=0.5)
+        )
+        stats = self.db.get_user_stats("q1")
+        assert stats["dominant_quadrant"] == "Dynamic Upper (Energetic Positive)"
+
+    def test_dominant_quadrant_static_upper(self):
+        """Positive upper_downer and non-positive static_dynamic → Static Upper."""
+        self.db.store_dream(
+            _make_record(user_id="q2", upper_downer=0.5, static_dynamic=0.0)
+        )
+        stats = self.db.get_user_stats("q2")
+        assert stats["dominant_quadrant"] == "Static Upper (Peaceful Positive)"
+
+    def test_dominant_quadrant_dynamic_downer(self):
+        """Non-positive upper_downer and positive static_dynamic → Dynamic Downer."""
+        self.db.store_dream(
+            _make_record(user_id="q3", upper_downer=-0.5, static_dynamic=0.5)
+        )
+        stats = self.db.get_user_stats("q3")
+        assert stats["dominant_quadrant"] == "Dynamic Downer (Chaotic Negative)"
+
+    def test_dominant_quadrant_static_downer(self):
+        """Non-positive upper_downer and non-positive static_dynamic → Static Downer."""
+        self.db.store_dream(
+            _make_record(user_id="q4", upper_downer=0.0, static_dynamic=0.0)
+        )
+        stats = self.db.get_user_stats("q4")
+        assert stats["dominant_quadrant"] == "Static Downer (Stagnant Negative)"

--- a/tests/test_symbol_generator.py
+++ b/tests/test_symbol_generator.py
@@ -147,17 +147,21 @@ class TestAISymbolGenerator:
 
     @pytest.mark.asyncio
     async def test_generate_symbol_prompt_contains_keywords(self):
-        """Prompt should include the dream's keywords."""
+        """Prompt should include keywords aggregated across all dreams."""
         mock_create = AsyncMock(return_value=self._make_mock_response())
         self.mock_client.images.generate = mock_create
 
         await self.generator.generate_symbol(
-            [_make_dream(keywords=["labyrinth", "ouroboros"])]
+            [
+                _make_dream(keywords=["labyrinth", "ouroboros"]),
+                _make_dream(keywords=["chrysalis", "mirror"]),
+            ]
         )
 
         prompt = mock_create.call_args.kwargs["prompt"]
-        assert "labyrinth" in prompt
-        assert "ouroboros" in prompt
+        # Most-recent dream's keywords take priority in the 5-keyword slot
+        assert "chrysalis" in prompt
+        assert "mirror" in prompt
 
     @pytest.mark.asyncio
     async def test_generate_symbol_prompt_positive_tone(self):
@@ -201,3 +205,22 @@ class TestAISymbolGenerator:
 
         assert isinstance(result, str)
         assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_generate_symbol_uses_averaged_scores(self):
+        """Scores should be averaged across all dreams, not taken from the last one."""
+        mock_create = AsyncMock(return_value=self._make_mock_response())
+        self.mock_client.images.generate = mock_create
+
+        # Two dreams with opposite tones — average is neutral, not uplifting or melancholic
+        await self.generator.generate_symbol(
+            [
+                _make_dream(upper_downer=0.8),  # very positive
+                _make_dream(upper_downer=-0.8),  # very negative
+            ]
+        )
+
+        prompt = mock_create.call_args.kwargs["prompt"]
+        assert "luminous and uplifting" not in prompt
+        assert "shadowy and melancholic" not in prompt
+        assert "mysterious and neutral" in prompt

--- a/tests/test_symbol_generator.py
+++ b/tests/test_symbol_generator.py
@@ -1,9 +1,10 @@
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from dream_interpreter.models import DreamAnalysis, DreamRecord
-from dream_interpreter.symbol_generator import SymbolGenerator
+from dream_interpreter.symbol_generator import AISymbolGenerator, SymbolGenerator
 
 
 class TestSymbolGenerator:
@@ -75,3 +76,128 @@ class TestSymbolGenerator:
         # Test lower-left quadrant (negative, static)
         color = self.generator._get_primary_color(-0.5, -0.5)
         assert color in self.generator.colors["downer"]
+
+
+def _make_dream(
+    upper_downer: float = 0.5,
+    static_dynamic: float = 0.5,
+    keywords: list = None,
+) -> DreamRecord:
+    """Build a minimal DreamRecord for testing."""
+    return DreamRecord(
+        id="test1",
+        dream_text="A test dream",
+        user_id="user1",
+        analysis=DreamAnalysis(
+            upper_downer_score=upper_downer,
+            static_dynamic_score=static_dynamic,
+            confidence=0.8,
+            keywords=keywords or ["flying"],
+        ),
+        timestamp=datetime(2026, 1, 1),
+    )
+
+
+class TestAISymbolGenerator:
+    """Test cases for the AISymbolGenerator class."""
+
+    def setup_method(self):
+        """Set up test fixtures with a mock OpenAI client."""
+        self.mock_client = MagicMock()
+        self.generator = AISymbolGenerator(openai_client=self.mock_client)
+
+    def _make_mock_response(self, b64: str = "ZmFrZWltYWdl") -> MagicMock:
+        """Build a fake OpenAI images.generate response."""
+        mock_image = MagicMock()
+        mock_image.b64_json = b64
+        mock_response = MagicMock()
+        mock_response.data = [mock_image]
+        return mock_response
+
+    @pytest.mark.asyncio
+    async def test_generate_symbol_returns_base64_from_api(self):
+        """generate_symbol should return the b64_json string from the API response."""
+        self.mock_client.images.generate = AsyncMock(
+            return_value=self._make_mock_response("ZmFrZWltYWdl")
+        )
+        result = await self.generator.generate_symbol([_make_dream()])
+        assert result == "ZmFrZWltYWdl"
+
+    @pytest.mark.asyncio
+    async def test_generate_symbol_uses_dall_e_3(self):
+        """generate_symbol should request a dall-e-3 image."""
+        mock_create = AsyncMock(return_value=self._make_mock_response())
+        self.mock_client.images.generate = mock_create
+
+        await self.generator.generate_symbol([_make_dream()])
+
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["model"] == "dall-e-3"
+
+    @pytest.mark.asyncio
+    async def test_generate_symbol_requests_b64_json(self):
+        """generate_symbol should request base64 response format, not a URL."""
+        mock_create = AsyncMock(return_value=self._make_mock_response())
+        self.mock_client.images.generate = mock_create
+
+        await self.generator.generate_symbol([_make_dream()])
+
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["response_format"] == "b64_json"
+
+    @pytest.mark.asyncio
+    async def test_generate_symbol_prompt_contains_keywords(self):
+        """Prompt should include the dream's keywords."""
+        mock_create = AsyncMock(return_value=self._make_mock_response())
+        self.mock_client.images.generate = mock_create
+
+        await self.generator.generate_symbol(
+            [_make_dream(keywords=["labyrinth", "ouroboros"])]
+        )
+
+        prompt = mock_create.call_args.kwargs["prompt"]
+        assert "labyrinth" in prompt
+        assert "ouroboros" in prompt
+
+    @pytest.mark.asyncio
+    async def test_generate_symbol_prompt_positive_tone(self):
+        """Dreams with high upper_downer should produce an uplifting prompt."""
+        mock_create = AsyncMock(return_value=self._make_mock_response())
+        self.mock_client.images.generate = mock_create
+
+        await self.generator.generate_symbol([_make_dream(upper_downer=0.8)])
+
+        prompt = mock_create.call_args.kwargs["prompt"]
+        assert "luminous and uplifting" in prompt
+
+    @pytest.mark.asyncio
+    async def test_generate_symbol_prompt_negative_tone(self):
+        """Dreams with low upper_downer should produce a melancholic prompt."""
+        mock_create = AsyncMock(return_value=self._make_mock_response())
+        self.mock_client.images.generate = mock_create
+
+        await self.generator.generate_symbol([_make_dream(upper_downer=-0.8)])
+
+        prompt = mock_create.call_args.kwargs["prompt"]
+        assert "shadowy and melancholic" in prompt
+
+    @pytest.mark.asyncio
+    async def test_generate_symbol_empty_dreams_uses_legacy(self):
+        """An empty dream list should fall back to the legacy generator without an API call."""
+        mock_create = AsyncMock(return_value=self._make_mock_response())
+        self.mock_client.images.generate = mock_create
+
+        result = await self.generator.generate_symbol([])
+
+        mock_create.assert_not_called()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_generate_symbol_falls_back_on_api_error(self):
+        """An OpenAI API error should fall back to the legacy generator silently."""
+        self.mock_client.images.generate = AsyncMock(side_effect=Exception("API error"))
+        result = await self.generator.generate_symbol([_make_dream()])
+
+        assert isinstance(result, str)
+        assert len(result) > 0


### PR DESCRIPTION
 ---                   
  Summary
                                                                                                                    
  - LLM dream analyser — replaced the rule-based TextBlob + 81-word keyword list with a Claude API call
  (claude-haiku-4-5) using structured tool use. The model scores both axes and extracts open-vocabulary keywords in 
  a single request, understanding context, negation, and words like "labyrinth" or "ouroboros" that the old system
  would miss entirely. The legacy analyser is kept as an automatic fallback when ANTHROPIC_API_KEY is absent.       
  - AI symbol generation — added a DALL-E 3 image generator that builds a prompt from the dream's keywords and
  scores (e.g. "shadowy and melancholic, still and contemplative, incorporating labyrinth, mirrors, ouroboros…") in 
  place of the deterministic matplotlib geometry. Falls back to the legacy matplotlib generator on empty dream lists
   or API errors.                                                                                                   
  - Classic / AI toggle — the web UI has a toggle switch that lets you switch between the two stacks per request
  without restarting the server. A Claude or Classic badge appears on keywords and a DALL·E 3 or Classic badge on   
  the symbol so it's always clear which stack produced the result. A loading message is shown while DALL·E 3
  generates (~20s).                                                                                                 
  - .env support — added python-dotenv so local dev picks up API keys from a .env file automatically on make run.
  Relevant variables: ANTHROPIC_API_KEY, OPENAI_API_KEY, ENABLE_AI_SYMBOLS.                                         
  - Tests — added 8 tests for LLMDreamanalyser and 8 for AISymbolGenerator, both using injected mock clients so no
  real API calls are made in CI. Added 20 tests for DreamDatabase (100% line coverage). Added CLAUDE.md project     
  guide.                                                       
  - Tooling — added isort profile = "black" to pyproject.toml to permanently fix the Black/isort formatter conflict.
   Overall test coverage: 86%.           
- Add CLAUDE.md with project architecture, conventions, and dev commands
- Ignore coverage.xml and .claude/ in .gitignore                                                                           
   
  Test plan                                                                                                         
                                                               
  - make test — 52 tests, all green  
  -  Add tests/test_database.py with 20 tests covering all public methods of DreamDatabase (100% line coverage)                                                                                
  - make lint-ci — source 9.44/10, tests 9.52/10
  - Set ANTHROPIC_API_KEY in .env and submit a dream — confirm Claude scores it and extracts novel keywords         
  - Set OPENAI_API_KEY + ENABLE_AI_SYMBOLS=true and toggle to AI mode — confirm DALL·E 3 image renders              
  - Leave both keys unset — confirm the app falls back to Classic stack without errors                              
                                                                                      